### PR TITLE
Update RTC_DS3231.cpp

### DIFF
--- a/RTC_DS3231.cpp
+++ b/RTC_DS3231.cpp
@@ -37,7 +37,7 @@ uint8_t RTC_DS3231::begin(void)
 uint8_t RTC_DS3231::isrunning(void)
 {
     Wire.beginTransmission(DS3231_ADDRESS);
-    Wire.SEND(0);
+    Wire.SEND(DS3231_REG_STATUS_CTL);
     Wire.endTransmission();
 
     Wire.requestFrom(DS3231_ADDRESS, 1);


### PR DESCRIPTION
Fix to RTC_DS3231::isrunning(), which previously always returned true.

The correct way to detect whether the ChronoDot clock has been interrupted is to check the 7th bit of the status register (0x0F).  The previous version of RTC_DS3231::isrunning() checked the 7th bit of register 0x00, which will always be unset.

It probably also makes sense to clear that bit (7th bit of 0x0F) when setting the time, in RTC_DS3231::adjust().  The bit will then remain clear for as long as the ChronoDot retains battery power.  That is not part of this change.